### PR TITLE
Add option for `rpmlintPath`

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Lint RPM spec files with rpmlint"
+                },
+                "rpmspec.rpmlintPath": {
+                    "type": "string",
+                    "default": "rpmlint",
+                    "description": "Path to 'rpmlint' command"
                 }
             }
         }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es6",
+        "target": "es2018",
         "outDir": "out",
         "lib": [
-            "es6"
+            "es2018"
         ],
         "sourceMap": true,
         "rootDir": "."


### PR DESCRIPTION
Hi, I'm not sure if this repo is still maintained (it's the most downloaded RPM spec extension on the marketplace!) but I added an option which I think makes it a little easier to run this extension in other environments (for example I am using on macOS now using a CentOS docker container with an `rpmlint` entrypoint).

The changes are:
* Obtain the path to `rpmlint` from configuration (`rpmspec.rpmlintPath`)
* Also pass PATH env variable through to spawn options so that custom rpmlint
installs work as expected.
* Rework diagnostic regex to include file-level diagnostics and add them to line 0, char 0.
* Update to ES2018 for named regex match groups. Slightly more readable regex

If you'd prefer I can break these up into multiple PRs, but none of the changes were very big so I thought together made sense.